### PR TITLE
Modified BitHamming, Using int32 to parse the vector

### DIFF
--- a/src/main/java/com/amazon/opendistroforelasticsearch/knn/index/KNNQuery.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/knn/index/KNNQuery.java
@@ -46,17 +46,25 @@ public class KNNQuery extends Query {
     public float[] getQueryVector() {
         return this.queryVector;
     }
-    public String getQueryVectorStr() {
 
-        //[1,0,1,0,1] --> "1 0 1 0 1"
-        char[] charArray = new char[this.queryVector.length*2];
-        for (int bit = 0; bit < this.queryVector.length; ++bit) {
-            int oneBit = ((int)(this.queryVector[bit]))%2;
-            charArray[bit*2] = (char) ('0' + oneBit);
-            charArray[bit*2+1] = ' ';
+    public int[] getQueryVectorInt() {
+        int[] queryVectorI = new int[queryVector.length];
+        for(int i = 0; i < queryVector.length; ++i) {
+            queryVectorI[i] = (int)queryVector[i];
         }
-        return String.valueOf(charArray);
+        return queryVectorI;
     }
+//    public String getQueryVectorStr() {
+//
+//        //[1,0,1,0,1] --> "1 0 1 0 1"
+//        char[] charArray = new char[this.queryVector.length*2];
+//        for (int bit = 0; bit < this.queryVector.length; ++bit) {
+//            int oneBit = ((int)(this.queryVector[bit]))%2;
+//            charArray[bit*2] = (char) ('0' + oneBit);
+//            charArray[bit*2+1] = ' ';
+//        }
+//        return String.valueOf(charArray);
+//    }
 
     public int getK() {
         return this.k;

--- a/src/main/java/com/amazon/opendistroforelasticsearch/knn/index/KNNWeight.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/knn/index/KNNWeight.java
@@ -99,11 +99,11 @@ public class KNNWeight extends Weight {
             Path indexPath = PathUtils.get(directory, hnswFiles.get(0));
             final KNNIndex index = knnIndexCache.getIndex(indexPath.toString(), knnQuery.getIndexName());
             final KNNQueryResult[] results;
-            boolean stringSapces = SpaceTypes.getStringSpaces().contains(index.getSpaceType());
+            boolean intSpaces = SpaceTypes.getIntSpaces().contains(index.getSpaceType());
 
-            if (stringSapces) {
+            if (intSpaces) {
                 results = index.queryIndex(
-                        knnQuery.getQueryVectorStr(),
+                        knnQuery.getQueryVectorInt(),
                         knnQuery.getK()
                 );
             } else {

--- a/src/main/java/com/amazon/opendistroforelasticsearch/knn/index/SpaceTypes.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/knn/index/SpaceTypes.java
@@ -62,7 +62,7 @@ public enum SpaceTypes {
     return new HashSet<>(Arrays.asList(cosinesimil.getValue(), l2.getValue()));
   }
 
-  public static Set<String> getStringSpaces() {
+  public static Set<String> getIntSpaces() {
     return new HashSet<>(Arrays.asList(bit_hamming.getValue()));
   }
 }

--- a/src/main/java/com/amazon/opendistroforelasticsearch/knn/index/codec/KNN80Codec/KNN80DocValuesConsumer.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/knn/index/codec/KNN80Codec/KNN80DocValuesConsumer.java
@@ -90,30 +90,28 @@ class KNN80DocValuesConsumer extends DocValuesConsumer implements Closeable {
             String indexPath = Paths.get(((FSDirectory) (FilterDirectory.unwrap(state.directory))).getDirectory().toString(),
                     hnswFileName).toString();
 
-
             // Pass the path for the nms library to save the file
             String tempIndexPath = indexPath + TEMP_SUFFIX;
             Map<String, String> fieldAttributes = field.attributes();
             String spaceType = fieldAttributes.getOrDefault(KNNConstants.SPACE_TYPE, SpaceTypes.l2.getValue());
             String[] algoParams = getKNNIndexParams(fieldAttributes);
             KNNCodecUtil.Pair pair;
-            boolean stringSapces = SpaceTypes.getStringSpaces().contains(spaceType);
+            boolean intSpaces = SpaceTypes.getIntSpaces().contains(spaceType);
 
-            if (stringSapces) {
-                pair = KNNCodecUtil.getStrings(values);
+            if (intSpaces) {
+                pair = KNNCodecUtil.getInts(values);
             } else {
                 pair = KNNCodecUtil.getFloats(values);
             }
-            if (pair == null || (pair.vectors.length == 0 && pair.vectorsStr.length == 0) || pair.docs.length == 0) {
+            if (pair == null || (pair.vectors.length == 0 && pair.vectorsInt.length == 0) || pair.docs.length == 0) {
                 logger.info("Skipping hnsw index creation as there are no vectors or docs in the documents");
                 return;
             }
-
             AccessController.doPrivileged(
                     new PrivilegedAction<Void>() {
                         public Void run() {
-                            if (stringSapces) {
-                                KNNIndex.saveIndex(pair.docs, pair.vectorsStr, tempIndexPath, algoParams, spaceType);
+                            if (intSpaces) {
+                                KNNIndex.saveIndex(pair.docs, pair.vectorsInt, tempIndexPath, algoParams, spaceType);
                             } else {
                                 KNNIndex.saveIndex(pair.docs, pair.vectors, tempIndexPath, algoParams, spaceType);
                             }

--- a/src/main/java/com/amazon/opendistroforelasticsearch/knn/index/codec/KNNCodecUtil.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/knn/index/codec/KNNCodecUtil.java
@@ -34,15 +34,24 @@ public class KNNCodecUtil {
         public Pair(int[] docs, float[][] vectors) {
             this.docs = docs;
             this.vectors = vectors;
-            vectorsStr = new String[0];
+            this.vectorsStr = new String[0];
+            this.vectorsInt = new int[0][0];
+        }
+        public Pair(int[] docs, int[][] vectorsInt) {
+            this.docs = docs;
+            this.vectorsInt = vectorsInt;
+            this.vectors = new float[0][0];
+            this.vectorsStr = new String[0];
         }
         public Pair(int[] docs, String[] vectorsStr) {
             this.docs = docs;
-            this.vectors = new float[0][0];
             this.vectorsStr = vectorsStr;
+            this.vectors = new float[0][0];
+            this.vectorsInt = new int[0][0];
         }
         public int[] docs;
         public float[][] vectors;
+        public int[][] vectorsInt;
         public String[] vectorsStr;
     }
 
@@ -62,7 +71,26 @@ public class KNNCodecUtil {
         }
         return new KNNCodecUtil.Pair(docIdList.stream().mapToInt(Integer::intValue).toArray(), vectorList.toArray(new float[][]{}));
     }
-
+    public static KNNCodecUtil.Pair getInts(BinaryDocValues values) throws IOException {
+        ArrayList<int[]> vectorList = new ArrayList<>();
+        ArrayList<Integer> docIdList = new ArrayList<>();
+        for (int doc = values.nextDoc(); doc != DocIdSetIterator.NO_MORE_DOCS; doc = values.nextDoc()) {
+            BytesRef bytesref = values.binaryValue();
+            try (ByteArrayInputStream byteStream = new ByteArrayInputStream(bytesref.bytes, bytesref.offset, bytesref.length);
+                 ObjectInputStream objectStream = new ObjectInputStream(byteStream)) {
+                float[] vector = (float[]) objectStream.readObject();
+                int[] vectorInt = new int[vector.length];
+                for(int i = 0; i < vector.length; ++i) {
+                    vectorInt[i] = (int) vector[i];
+                }
+                vectorList.add(vectorInt);
+            } catch (ClassNotFoundException e) {
+                throw new RuntimeException(e);
+            }
+            docIdList.add(doc);
+        }
+        return new KNNCodecUtil.Pair(docIdList.stream().mapToInt(Integer::intValue).toArray(), vectorList.toArray(new int[][]{}));
+    }
     public static KNNCodecUtil.Pair getStrings(BinaryDocValues values) throws IOException {
         ArrayList<String> vectorList = new ArrayList<>();
         ArrayList<Integer> docIdList = new ArrayList<>();

--- a/src/main/java/com/amazon/opendistroforelasticsearch/knn/index/v206/KNNIndex.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/knn/index/v206/KNNIndex.java
@@ -174,7 +174,12 @@ public class KNNIndex implements AutoCloseable {
             return;
         }
         try {
-            gc(this.indexPointer);
+            boolean intSpaces = SpaceTypes.getIntSpaces().contains(spaceType);
+            if(intSpaces) {
+                gcI(this.indexPointer);
+            } else {
+                gc(this.indexPointer);
+            }
         } finally {
             this.isClosed = true;
             writeLock.unlock();
@@ -191,10 +196,10 @@ public class KNNIndex implements AutoCloseable {
      */
     public static KNNIndex loadIndex(String indexPath, final String[] algoParams, final String spaceType) {
         long fileSize = computeFileSize(indexPath);
-        boolean stringSapces = SpaceTypes.getStringSpaces().contains(spaceType);
+        boolean intSpaces = SpaceTypes.getIntSpaces().contains(spaceType);
         boolean loadData = !SpaceTypes.getOptimizedValues().contains(spaceType);
         long indexPointer;
-        if (stringSapces) {
+        if (intSpaces) {
             indexPointer = initI(indexPath, algoParams, spaceType, loadData);
         } else {
             indexPointer = init(indexPath, algoParams, spaceType, loadData);

--- a/src/test/java/com/amazon/opendistroforelasticsearch/knn/index/KNNESIT.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/knn/index/KNNESIT.java
@@ -236,7 +236,18 @@ public class KNNESIT extends KNNRestTestCase {
         assertThat(ex.getMessage(), containsString("Dimension value cannot be greater than " +
                 KNNVectorFieldMapper.MAX_DIMENSION + " for vector: " + FIELD_NAME));
     }
+    public void testVectorMappingValidationInvalidBitDimension() {
+        Settings settings = Settings.builder()
+                .put(getKNNDefaultIndexSettings())
+                .put(KNNSettings.KNN_SPACE_TYPE, SpaceTypes.bit_hamming.getValue())
+                .build();
 
+        Exception ex = expectThrows(ResponseException.class, () -> createKnnIndex(INDEX_NAME, settings,
+                createKnnIndexMapping(FIELD_NAME, KNNVectorFieldMapper.MAX_DIMENSION * 32+ 1)));
+
+        assertThat(ex.getMessage(), containsString("Bit Dimension value cannot be greater than " +
+                KNNVectorFieldMapper.MAX_DIMENSION * 32 + " for vector: " + FIELD_NAME));
+    }
     public void testVectorMappingValidationInvalidVectorNaN() throws IOException {
         Settings settings = Settings.builder()
                 .put(getKNNDefaultIndexSettings())

--- a/src/test/java/com/amazon/opendistroforelasticsearch/knn/index/KNNJNITests.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/knn/index/KNNJNITests.java
@@ -210,8 +210,61 @@ public class KNNJNITests extends KNNTestCase {
         dir.close();
     }
 
+    public void testAddAndQueryHnswIndexBitHammingWithInt() throws Exception {
+        int[] docs = {0, 1, 2, 3, 4, 5};
 
-    public void testAddAndQueryHnswIndexBitHamming() throws Exception {
+        int[][] vectors = {
+                {0,0,0},   //0*28, 0000, 0*28, 0000, 0*28, 0000
+                {1,0,5},   //0*28, 0001, 0*28, 0000, 0*28, 0101
+                {0,5,1},   //0*28, 0000, 0*28, 0101, 0*28, 0001
+                {8,4,1},   //0*28, 1000, 0*28, 0100, 0*28, 0001
+                {1,1,4},   //0*28, 0001, 0*28, 0001, 0*28, 0100
+                {-1,-1,-1} //1*27, 1111, 1*28, 1111, 1*28, 1111
+        };
+
+        Directory dir = newFSDirectory(createTempDir());
+        String segmentName = "_dummy1";
+        String indexPath = Paths.get(((FSDirectory) (FilterDirectory.unwrap(dir))).getDirectory().toString(),
+                String.format("%s.hnsw", segmentName)).toString();
+
+        String[] algoParams = {};
+        AccessController.doPrivileged(
+                new PrivilegedAction<Void>() {
+                    public Void run() {
+                        KNNIndex.saveIndexI(docs, vectors, indexPath, algoParams, "bit_hamming", true);
+                        return null;
+                    }
+                }
+        );
+
+        assertTrue(Arrays.asList(dir.listAll()).contains("_dummy1.hnsw"));
+        assertTrue(Arrays.asList(dir.listAll()).contains("_dummy1.hnsw.dat"));
+
+        int[] queryVector = {0, 5, 1};
+        String[] algoQueryParams = {"efSearch=20"};
+
+        final KNNIndex knnIndex = KNNIndex.loadIndex(indexPath, algoQueryParams, "bit_hamming");
+        final KNNQueryResult[] results = knnIndex.queryIndex(queryVector, 30);
+
+        Map<Integer, Float> scores = Arrays.stream(results).collect(
+                Collectors.toMap(result -> result.getId(), result -> result.getScore()));
+        logger.info(scores);
+
+        assertEquals(results.length, 6);
+        /*
+         * scores are evaluated using bit_hamming. Distance of the documents with
+         * respect to query vector are as follows
+         * doc0 = 3.0, doc1 = 4.0, doc2 = 0.0, doc3 = 2.0, doc4 = 4.0
+         */
+        assertEquals(scores.get(0), 3.0, 1e-4);
+        assertEquals(scores.get(1), 4.0, 1e-4);
+        assertEquals(scores.get(2), 0.0, 1e-4);
+        assertEquals(scores.get(3), 2.0, 1e-4);
+        assertEquals(scores.get(4), 4.0, 1e-4);
+        assertEquals(scores.get(5), 93.0, 1e-4);
+        dir.close();
+    }
+    public void testAddAndQueryHnswIndexBitHammingWithString() throws Exception {
         int[] docs = {0, 1, 2, 3, 4};
 
         String[] vectors = {


### PR DESCRIPTION

Previously, We use string to parse the bit vector, this method occupy too much memory!
As i checked the code: space_bit_hamming.h in nmslib, i think use a int32 to represent bit vector is better